### PR TITLE
Expose Interop_SetOverride directly.

### DIFF
--- a/interoplib.c
+++ b/interoplib.c
@@ -233,7 +233,7 @@ bool Interop_GenerateInstanceId(char *String, int32_t MaxString) {
 
 /*********************************************************************/
 
-bool InteropLib_SetOverride(const char *Key, void *Value) {
+bool Interop_SetOverride(const char *Key, void *Value) {
     if (strcmp(Key, "Class_ConvertFromInstanceId") == 0)
         Class_ConvertFromInstanceIdPtr = (Class_ConvertFromInstanceIdCallback)Value;
     else if (strcmp(Key, "Class_ConvertToInstanceId") == 0)

--- a/interoplib.h
+++ b/interoplib.h
@@ -87,10 +87,6 @@ bool Interop_GenerateInstanceId(char *String, int32_t MaxString);
 
 /*********************************************************************/
 
-bool InteropLib_SetOverride(const char *Key, void *Value);
-
-/*********************************************************************/
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This is so Interop libraries that use this wrapper library don't have to implement the `Interop_SetOverride` function, and they shouldn't need to.