### PR TITLE
Remove out of date example of Interop_SetOverride

### DIFF
--- a/docs/interop.md
+++ b/docs/interop.md
@@ -56,13 +56,6 @@ Called to provide function callbacks for DIRECT client functions.
 
 Return true if successfully, false otherwise.
 
-```c
-bool Interop_SetOverride(const char *Key, void *Value) {
-    InteropLib_SetOverride(Key, Value);
-    return true;
-}
-```
-
 ### Interop_SetOption
 
 Called whenever a client configuration option changes.


### PR DESCRIPTION
This is entirely handled by interop-lib now.